### PR TITLE
update to latest version of ruby

### DIFF
--- a/lib/phidgets-ffi/ffi/common.rb
+++ b/lib/phidgets-ffi/ffi/common.rb
@@ -45,7 +45,7 @@ module Phidgets
     attach_function :CPhidget_set_OnError_Handler, [:phid, :CPhidget_set_OnError_Callback, :user_ptr], :int
     
 
-	if Config::CONFIG['target_os'] =~ /darwin/ #Mac OS X
+	if RbConfig::CONFIG['target_os'] =~ /darwin/ #Mac OS X
 		callback :CPhidget_set_OnWillSleep_Callback, [:user_ptr], :int
 		attach_function :CPhidget_set_OnWillSleep_Handler, [:CPhidget_set_OnWillSleep_Callback, :user_ptr], :int
 		callback :CPhidget_set_OnWakeup_Callback, [:user_ptr], :int

--- a/lib/phidgets-ffi/ffi/manager.rb
+++ b/lib/phidgets-ffi/ffi/manager.rb
@@ -1,7 +1,7 @@
 module Phidgets
   module FFI
 
-	if Config::CONFIG['target_os'] =~ /darwin/ #Mac OS X
+	if RbConfig::CONFIG['target_os'] =~ /darwin/ #Mac OS X
 		FFI_POINTER_SIZE = 4  
     else  #Linux
 		FFI_POINTER_SIZE = 8  


### PR DESCRIPTION
this should remove some of the warnings for newer versions of ruby
